### PR TITLE
Makefile for unix systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.dbg
 examples/01_XandY
 examples/04_RPG_Subroutines
 examples/*.deb

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Makefile recipe for Assembly Crash Course
+
+# Toolchain vars
+AS=cl65
+TGT=nes
+ASFLAGS=--verbose --target $(TGT)
+
+SRCDIR=examples
+BUILDDIR=build
+
+# Targets
+%.nes: $(SRCDIR)/%.s
+	if [[ ! -d $(BUILDDIR) ]]; then mkdir $(BUILDDIR); fi;
+	$(AS) $(ASFLAGS) -o $(BUILDDIR)/$@ wrapper.s $^
+
+clean:
+	find . -type f -iname "*.o" -exec rm {} \;
+	$(RM) -r $(BUILDDIR)
+
+.PHONY: clean


### PR DESCRIPTION
## PR description

This PR aims to add a Makefile recipe for UNIX-like systems to ease build of each
Assembly Crash Course source files.

It builds NES ROMs executable in a `build` directory and take carry of cleaning root and sub-directories from `*.o` object files.

It also ease new source file additions by using a **pattern matching** target and allow users to run for example: `make 01_XAndY.nes` to assemble `examples/01_XAndY.s` and `wrapper.s` source files in the `build` directory.

So any source file additions in the `example` directory can next be build using the same command pattern.

This update will requires GNU make program to be able to run the build.
It can be found in pretty almost UNIX systems packages (GNU/Linux distros, BSD-like, ...)

---

The second request is to add `*.dbg` files pattern to `.gitignore` file, those are created by FCEUX emulator to save some debugging sessions info such as breakpoints position and options.

### Adds

- Makefile: Add recipe

### Updates

- .gitignore

### Removes

- None